### PR TITLE
Move Redis to use List instead of Set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 .ruby-version
 Gemfile.lock
 *.swp
+tags

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ end
 
 You need 2 additional parameters(compared to the `Memory` adapter), they are defined as such:
 
-- `client` - an instance of a `Redis` client.  This gem does not have a hard dependency on a particular redis client but for testing I've used [redis-rb](https://github.com/redis/redis-rb).  Whatever you pass in here simply has to implement a few redis commands such as `sadd`, `del`, `smembers`, `get` and `set`.  The client will ensure these exist before the breaker can be instantiated.
+- `client` - an instance of a `Redis` client.  This gem does not have a hard dependency on a particular redis client but for testing I've used [redis-rb](https://github.com/redis/redis-rb).  Whatever you pass in here simply has to implement a few redis commands.  The client will ensure these exist before the breaker can be instantiated.
 - `namespace` - A unique name that will be used across servers to sync `state` and `failures`.  I'd recommend `class_name:some_method` or whatever is special about what's being invoked in the `circuit`.
 
 #### Roll Your Own Circuit Breaker
@@ -106,6 +106,9 @@ class MyPreferredStore
   include SwitchGear::CircuitBreaker
 end
 ```
+## Sidekiq
+
+I've [written a middleware](https://github.com/allcentury/switch_gear_sidekiq-middleware) for use with Sidekiq.
 
 ## Forthcoming
 

--- a/lib/switch_gear.rb
+++ b/lib/switch_gear.rb
@@ -1,3 +1,4 @@
 require_relative 'switch_gear/circuit_breaker'
+require_relative 'switch_gear/version'
 module SwitchGear
 end

--- a/lib/switch_gear/circuit_breaker/failure.rb
+++ b/lib/switch_gear/circuit_breaker/failure.rb
@@ -6,7 +6,7 @@ module SwitchGear
         failure = JSON.parse(json)
         error = Object.const_get(failure["error"])
         error = error.new(failure["message"])
-        new(error, Time.parse(failure["timestamp"]))
+        new(error, Time.at(failure["timestamp"]).utc)
       end
 
       def initialize(error, recorded = Time.now.utc)
@@ -26,7 +26,7 @@ module SwitchGear
         JSON.generate({
           error: error.class,
           message: error.message,
-          timestamp: timestamp.to_s
+          timestamp: timestamp.to_i
         })
       end
 

--- a/lib/switch_gear/version.rb
+++ b/lib/switch_gear/version.rb
@@ -1,3 +1,3 @@
 module SwitchGear
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end

--- a/spec/switch_gear/circuit_breaker/failure_spec.rb
+++ b/spec/switch_gear/circuit_breaker/failure_spec.rb
@@ -17,7 +17,7 @@ describe SwitchGear::CircuitBreaker::Failure do
       {
         error: error.class,
         message: error.message,
-        timestamp: time.to_s
+        timestamp: time.to_i
       }.to_json
     end
     before(:each) do


### PR DESCRIPTION
This change forces the breaker to use a list where each new failure is
appended to the tail of a redis linked-list.  This more closely matches
the in-memory solution.